### PR TITLE
Merging 'dev' into 'main'

### DIFF
--- a/src/af3cli/builder.py
+++ b/src/af3cli/builder.py
@@ -48,6 +48,18 @@ class InputBuilder(object):
         self._afinput = afinput
         return self
 
+    def reset_ids(self) -> Self:
+        """
+        Resets all IDs of ligands and sequences within the current `Input` object.
+
+        Returns
+        -------
+        Self
+            Returns the instance itself to allow method chaining.
+        """
+        self._afinput.reset_ids()
+        return self
+
     def build(self) -> InputFile:
         """
         Builds and retrieves the constructed `InputFile` instance.

--- a/src/af3cli/builder.py
+++ b/src/af3cli/builder.py
@@ -24,9 +24,29 @@ class InputBuilder(object):
     _id_register : IDRegister
         The ID register object managing unique ID allocation.
     """
-    def __init__(self):
-        self._afinput: InputFile = InputFile()
+    def __init__(self, afinput: InputFile | None = None):
+        if afinput is None:
+            afinput = InputFile()
+        self._afinput: InputFile = afinput
         self._id_register: IDRegister = IDRegister()
+
+    def attach(self, afinput: InputFile) -> Self:
+        """
+        Attaches an `InputFile` object to the current instance.
+
+        Parameters
+        ----------
+        afinput : InputFile
+            The input file to be attached to the object.
+
+        Returns
+        -------
+        self : object
+            Returns the instance of the current object with the attached input
+            file, allowing method chaining.
+        """
+        self._afinput = afinput
+        return self
 
     def build(self) -> InputFile:
         """

--- a/src/af3cli/input.py
+++ b/src/af3cli/input.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
 from .mixin import DictMixin
 from .ligand import Ligand
 from .bond import Bond
@@ -101,6 +105,67 @@ class InputFile(DictMixin):
             for entry in seqtype:
                 entry.remove_id()
         self._id_register.reset()
+
+    def merge(
+            self,
+            other: InputFile,
+            reset: bool = True,
+            seeds: bool = False,
+            bonded_atoms: bool = False,
+            userccd: bool = False
+    ) -> None:
+        """
+        Merges the content of another InputFile instance into the current
+        instance.
+
+        Notes
+        -----
+        No checks are performed to ensure that the IDs are handled correctly.
+        Please use with caution when no reset is performed or when keeping
+        bonded atoms.
+
+        Parameters
+        ----------
+        other : InputFile
+            An InputFile instance whose content will be merged into
+            the current instance.
+        reset : bool
+            If True (default), resets the IDs of the content being merged
+            to ensure unique identifiers.
+        seeds : bool
+            If True (default: False), merges the seeds from the `other`
+            InputFile instance into the current instance.
+        bonded_atoms : bool
+            If True (default: False), appends bonded atom information from
+            the `other` InputFile instance to the current instance.
+        userccd : bool
+            If True (default: False), overwrites the `user_ccd` attribute
+            of the current instance with the value from the `other` InputFile
+            instance.
+
+        Returns
+        -------
+        None
+            This method modifies the current instance in place; it does
+            not return any value.
+        """
+        tmp_input = deepcopy(other)
+
+        if reset:
+            tmp_input.reset_ids()
+        if seeds:
+            self.seeds.extend(tmp_input.seeds)
+        if bonded_atoms:
+            for bond in tmp_input.bonded_atoms:
+                self.bonded_atoms.append(bond)
+        if userccd:
+            self.user_ccd = tmp_input.user_ccd
+
+        for seq in tmp_input.sequences:
+            self.sequences.append(seq)
+
+        for lig in tmp_input.ligands:
+            self.ligands.append(lig)
 
     def to_dict(self) -> dict:
         """

--- a/src/af3cli/input.py
+++ b/src/af3cli/input.py
@@ -75,7 +75,6 @@ class InputFile(DictMixin):
                         self._id_register.register(seq_id)
                         entry.is_registered = True
 
-
     def _assign_ids(self) -> None:
         """
         Assign unique IDs to sequences and ligands that do not already have an ID.
@@ -90,10 +89,18 @@ class InputFile(DictMixin):
                     seq_ids = [self._id_register.generate() for _ in range(entry.num)]
                     entry.set_id(seq_ids)
 
-
     def _prepare(self) -> None:
         self._register_ids()
         self._assign_ids()
+
+    def reset_ids(self) -> None:
+        """
+        Resets the IDs of all entries in the object's sequences and ligands.
+        """
+        for seqtype in [self.sequences, self.ligands]:
+            for entry in seqtype:
+                entry.remove_id()
+        self._id_register.reset()
 
     def to_dict(self) -> dict:
         """

--- a/src/af3cli/io.py
+++ b/src/af3cli/io.py
@@ -281,15 +281,7 @@ class JSONReader(object):
         -------
         Optional[MSA]
             An MSA object if the input sequence content supports it, otherwise `None`.
-
-        Raises
-        ------
-        AFMSAError
-            If the sequence type is DNA and MSA is attempted to be parsed for it.
-            Also raised if paired MSA is provided for RNA sequences.
         """
-        if seq_type == SequenceType.DNA:
-            raise AFMSAError("MSA not supported for DNA sequences.")
         msa = None
 
         paired = seq_content.get("pairedMsa") or seq_content.get("pairedMsaPath")
@@ -337,7 +329,9 @@ class JSONReader(object):
         if "templates" in seq_content.keys():
             templates = JSONReader._parse_templates(seq_type, seq_content)
 
-        msa = JSONReader._parse_msa(seq_type, seq_content)
+        msa = None
+        if seq_type != SequenceType.DNA:
+            msa = JSONReader._parse_msa(seq_type, seq_content)
 
         return Sequence(
             seq_type=seq_type,

--- a/src/af3cli/seqid.py
+++ b/src/af3cli/seqid.py
@@ -64,8 +64,12 @@ class IDRecord(object):
     def get_id(self) -> list[str]:
         return self._seq_id
 
-    def set_id(self, seq_id: list[str]):
+    def set_id(self, seq_id: list[str]) -> None:
         self._seq_id = seq_id
+
+    def remove_id(self) -> None:
+        self._seq_id = None
+        self.is_registered = False
 
 
 class IDRegister(object):
@@ -123,3 +127,15 @@ class IDRegister(object):
             if seq_id not in self._registered_ids:
                 return seq_id
             self._count += 1
+
+    def reset(self) -> None:
+        """
+        Resets the `IDRegister` object.
+
+        Notes
+        -----
+        The ids and register states of corresponding sequence objects are
+        not affected.
+        """
+        self._count = 0
+        self._registered_ids = set()

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -105,3 +105,14 @@ def test_builder_attach(builder: InputBuilder) -> None:
     curr_input = builder.build()
     builder.attach(curr_input)
     assert builder._afinput == curr_input
+
+
+def test_builder_reset_ids(
+        builder: InputBuilder,
+        sample_sequence: Sequence
+) -> None:
+    builder.reset_ids()
+    curr_input = builder.build()
+    for seq_type in [curr_input.sequences, curr_input.ligands]:
+        for entry in seq_type:
+            assert entry.get_id() is None

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -17,7 +17,8 @@ def builder() -> InputBuilder:
 def sample_sequence() -> Sequence:
     return Sequence(
         seq_type=SequenceType.PROTEIN,
-        seq_str="MVKVGVNGFGRIGRLVTRAAFNS"
+        seq_str="MVKVGVNGFGRIGRLVTRAAFNS",
+        seq_id=["A", "B"]
     )
 
 
@@ -26,6 +27,7 @@ def sample_ligand() -> Ligand:
     return Ligand(
         ligand_type=LigandType.CCD,
         ligand_str="NAC",
+        seq_id=["C", "D"]
     )
 
 
@@ -111,8 +113,14 @@ def test_builder_reset_ids(
         builder: InputBuilder,
         sample_sequence: Sequence
 ) -> None:
-    builder.reset_ids()
     curr_input = builder.build()
+
+    for seq_type in [curr_input.sequences, curr_input.ligands]:
+        for entry in seq_type:
+            assert entry.get_id() is not None
+
+    builder.reset_ids()
+
     for seq_type in [curr_input.sequences, curr_input.ligands]:
         for entry in seq_type:
             assert entry.get_id() is None

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -99,3 +99,9 @@ def test_builder_build(builder: InputBuilder) -> None:
     assert len(afinput.sequences) > 0
     assert len(afinput.ligands) > 0
     assert len(afinput.bonded_atoms) > 0
+
+
+def test_builder_attach(builder: InputBuilder) -> None:
+    curr_input = builder.build()
+    builder.attach(curr_input)
+    assert builder._afinput == curr_input

--- a/tests/test_seqid.py
+++ b/tests/test_seqid.py
@@ -49,3 +49,9 @@ def test_id_register_multiple_letters(
 ) -> None:
     register.register(letter)
     assert letter in register._registered_ids
+
+
+def test_id_register_reset(register: IDRegister) -> None:
+    register.reset()
+    assert len(register._registered_ids) == 0
+    assert register._count == 0

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -221,7 +221,7 @@ def test_msa_to_dict(
     (SequenceType.PROTEIN, "MVKVGVNGF", ["A", "B"],
      MSA(paired="test", unpaired="test")
     ),
-    (SequenceType.RNA, "MVKVGVNGF", "C",
+    (SequenceType.RNA, "AUGUGUAU", "C",
      MSA(unpaired="test", unpaired_is_path=True)
     ),
     (SequenceType.PROTEIN, "MVKVGVNGF", ["A"],
@@ -253,3 +253,18 @@ def test_sequence_init_msa(
     if msa.unpaired_is_path:
         assert "unpairedMsaPath" in tmp_dict.keys()
         assert "unpairedMsa" not in tmp_dict.keys()
+
+@pytest.mark.parametrize("seq_type,seq_str,seq_id", [
+    (SequenceType.PROTEIN, "MVKVGVNGF", None),
+    (SequenceType.PROTEIN, "AAQAA", ["A", "B"]),
+    (SequenceType.RNA, "AUGUGUAU", "A"),
+    (SequenceType.DNA, "GACCTCT", ["C"])
+])
+def test_sequence_remove_id(
+        seq_type: SequenceType,
+        seq_str: str,
+        seq_id: list[str] | str | None,
+):
+    seq = Sequence(seq_type, seq_str, seq_id=seq_id)
+    seq.remove_id()
+    assert seq.get_id() is None


### PR DESCRIPTION
### Overview of Changes

#### New Features

- Enabled use of an existing `InputFile` object with `InputBuilder`.
- Merging two `InputFile` objects is now possible.
- Implemented functionality to reset `IDRegister` or IDs individual of sequences.
- Fixed handling of MSA sections when reading existing input files.

#### Testing

- Added unit tests for new features.

#### Notes

Merging two `InputFile` objects should be performed with caution as this might result in ID clashes (if no reset is performed) or incorrect assignment of bonded atoms (if a reset is performed).