### PR TITLE
Merging 'dev' into 'main'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
     "pytest>=8.3.4",
 ]
 features = [
+    "biopython>=1.84",
     "rdkit>=2024.9.4",
 ]
 

--- a/src/af3cli/__main__.py
+++ b/src/af3cli/__main__.py
@@ -17,6 +17,7 @@ from .sequence import Template, TemplateType, MSA
 from .sequence import (Modification, NucleotideModification,
                        ResidueModification)
 from .sequence import read_fasta, fasta2seq
+from .sequence import is_sequence_type
 from .io import JSONWriter, JSONReader
 
 # CONSTANTS
@@ -488,6 +489,10 @@ class SequenceCommand(CLICommand, metaclass=ABCMeta):
             self._sequence_str = read_fasta_entry(sequence)
         else:
             self._sequence_str = sequence
+
+        if not is_sequence_type(self.sequence_type(), self._sequence_str):
+            exit_on_error(f"Invalid sequence for '{self.sequence_type().name}'")
+
         self._sequence_ids = ids
         self._sequence_num = num
         return self

--- a/src/af3cli/__main__.py
+++ b/src/af3cli/__main__.py
@@ -16,6 +16,7 @@ from .sequence import Sequence, SequenceType
 from .sequence import Template, TemplateType, MSA
 from .sequence import (Modification, NucleotideModification,
                        ResidueModification)
+from .sequence import read_fasta
 from .io import JSONWriter, JSONReader
 
 # CONSTANTS
@@ -108,7 +109,7 @@ def read_sdf_file(filename: str) -> list[str]:
     Raises
     ------
     SystemExit
-        If RDKit is not installed on the system.
+        If RDKit is not installed on the system or file is not found.
     """
     try:
         smiles = []
@@ -120,8 +121,48 @@ def read_sdf_file(filename: str) -> list[str]:
             smiles.append(smi)
         logger.info(f"Read {len(smiles)} molecules from SDF file.")
         return smiles
+    except FileNotFoundError as e:
+        exit_on_error(f"SDF file not found: {e}")
     except ImportError as e:
-        exit_on_error(f"Please install RDKit to read SDF files ({e})")
+        exit_on_error(e.msg)
+    except Exception as e:
+        exit_on_error(f"Failed to read SDF file: {e}")
+
+
+def read_fasta_entry(filename: str) -> str:
+    """
+    Reads a single entry from a FASTA file and returns its sequence string.
+
+    Parameters
+    ----------
+    filename : str
+        The path to the FASTA file to be read.
+
+    Returns
+    -------
+    str
+        The sequence string from the first valid entry in the FASTA file.
+
+    Raises
+    ------
+    SystemExit
+        If Biopython is not installed or if the specified FASTA file
+        does not exist / contains no valid sequences.
+    """
+    try:
+        fasta_file = read_fasta(filename)
+        seq_name, seq_str = next(fasta_file)
+        if seq_str is None:
+            exit_on_error("No valid sequence found in FASTA file.")
+        return seq_str
+    except FileNotFoundError as e:
+        exit_on_error(f"FASTA file not found: {e}")
+    except StopIteration as e:
+        exit_on_error(f"No sequence found in FASTA file. {e}")
+    except ImportError as e:
+        exit_on_error(e.msg)
+    except Exception as e:
+        exit_on_error(f"Failed to read FASTA file: {e}")
 
 
 def read_file_to_str(filename) -> str:
@@ -368,7 +409,8 @@ class SequenceCommand(CLICommand, metaclass=ABCMeta):
         self,
         sequence: str,
         num: int | None = None,
-        ids: list[str] | None = None
+        ids: list[str] | None = None,
+        fasta: bool = False
     ) -> Self:
         """
         Adds a sequence and optionally specifies either a number or a list of IDs for the
@@ -377,7 +419,8 @@ class SequenceCommand(CLICommand, metaclass=ABCMeta):
         Parameters
         ----------
         sequence : str
-            A string representing the specific sequence to be added.
+            A string representing the specific sequence to be added or a path
+            to a FASTA file containing the sequence if `fasta` is set to True.
 
         num : int
             An integer that defines a number of sequences. Either
@@ -386,6 +429,9 @@ class SequenceCommand(CLICommand, metaclass=ABCMeta):
         ids : list of str
             A list of strings representing unique identifiers for the sequence.
             Either `ids` or `num` can be specified, but not both.
+
+        fasta: bool
+            If `True`, the sequence will be interpreted as a FASTA file.
 
         Returns
         -------
@@ -399,7 +445,10 @@ class SequenceCommand(CLICommand, metaclass=ABCMeta):
 
         ids = ensure_opt_str_list(ids)
 
-        self._sequence_str = sequence
+        if fasta:
+            self._sequence_str = read_fasta_entry(sequence)
+        else:
+            self._sequence_str = sequence
         self._sequence_ids = ids
         self._sequence_num = num
         return self

--- a/src/af3cli/__main__.py
+++ b/src/af3cli/__main__.py
@@ -10,7 +10,7 @@ from abc import ABCMeta, abstractmethod
 import fire
 
 from .builder import InputBuilder
-from .ligand import Ligand, LigandType
+from .ligand import Ligand, LigandType, sdf2smiles
 from .bond import Bond
 from .sequence import Sequence, SequenceType
 from .sequence import Template, TemplateType, MSA
@@ -94,12 +94,6 @@ def read_sdf_file(filename: str) -> list[str]:
     """
     Reads a Structure Data File (SDF) and converts the molecules into SMILES format.
 
-    This function uses RDKit to process the molecules in an SDF file and converts
-    them into the SMILES string representation. If any molecule cannot be read
-    from the file, it will be skipped with a warning message. The total number of
-    successfully converted molecules will be logged. If RDKit is not installed,
-    the function will terminate the program with an informative error message.
-
     Parameters
     ----------
     filename : str
@@ -117,14 +111,13 @@ def read_sdf_file(filename: str) -> list[str]:
         If RDKit is not installed on the system.
     """
     try:
-        from rdkit import Chem
-        supplier = Chem.SDMolSupplier(filename)
         smiles = []
-        for mol in supplier:
-            if mol is None:
+        smi_generator = sdf2smiles(filename)
+        for smi in smi_generator:
+            if smi is None:
                 logger.warning("Failed to read molecule from SDF file.")
                 continue
-            smiles.append(Chem.MolToSmiles(mol))
+            smiles.append(smi)
         logger.info(f"Read {len(smiles)} molecules from SDF file.")
         return smiles
     except ImportError as e:

--- a/src/af3cli/__main__.py
+++ b/src/af3cli/__main__.py
@@ -17,7 +17,7 @@ from .sequence import Template, TemplateType, MSA
 from .sequence import (Modification, NucleotideModification,
                        ResidueModification)
 from .sequence import read_fasta, fasta2seq
-from .sequence import is_sequence_type
+from .sequence import is_valid_sequence
 from .io import JSONWriter, JSONReader
 
 # CONSTANTS
@@ -490,7 +490,7 @@ class SequenceCommand(CLICommand, metaclass=ABCMeta):
         else:
             self._sequence_str = sequence
 
-        if not is_sequence_type(self.sequence_type(), self._sequence_str):
+        if not is_valid_sequence(self.sequence_type(), self._sequence_str):
             exit_on_error(f"Invalid sequence for '{self.sequence_type().name}'")
 
         self._sequence_ids = ids

--- a/src/af3cli/ligand.py
+++ b/src/af3cli/ligand.py
@@ -1,4 +1,5 @@
 from enum import StrEnum
+from typing import Generator
 
 from .mixin import DictMixin
 from .seqid import IDRecord
@@ -85,3 +86,40 @@ class Ligand(IDRecord, DictMixin):
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}>"
+
+
+def sdf2smiles(filename: str) -> Generator[str | None, None, None]:
+    """
+    Reads a Structure Data File (SDF) and converts the molecules into SMILES format.
+
+    This function uses RDKit to process the molecules in an SDF file and converts
+    them into the SMILES string representation. If any molecule cannot be read
+    from the file, it will be skipped with a warning message. The total number of
+    successfully converted molecules will be logged. If RDKit is not installed,
+    the function will terminate the program with an informative error message.
+
+    Parameters
+    ----------
+    filename : str
+        The path to the SDF file that needs to be read.
+
+    Returns
+    -------
+    Generator of str or None
+        A generator that yields SMILES strings representing the molecules
+        contained in the specified SDF file.
+
+    Raises
+    ------
+    ImportError
+        If RDKit is not installed on the system.
+    """
+    try:
+        from rdkit import Chem
+        supplier = Chem.SDMolSupplier(filename)
+        for mol in supplier:
+            if mol is None:
+                yield None
+            yield Chem.MolToSmiles(mol)
+    except ImportError as e:
+        raise ImportError("Please install RDKit to read SDF files") from e

--- a/src/af3cli/sequence.py
+++ b/src/af3cli/sequence.py
@@ -370,7 +370,7 @@ def read_fasta(filename: str) -> Generator[tuple[str, str], None, None]:
         raise ImportError("Please install Biopython to read FASTA files") from e
 
 
-def is_sequence_type(seq_type: SequenceType, seq_str: str) -> bool:
+def is_valid_sequence(seq_type: SequenceType, seq_str: str) -> bool:
     """
     Determines if a given sequence string corresponds to the specified sequence type.
 
@@ -416,9 +416,9 @@ def identify_sequence_type(seq_str: str) -> SequenceType | None:
         Returns None if the sequence is ambiguous (e.g., qualifies as both DNA and RNA)
         or does not fit any of the known sequence types.
     """
-    is_protein = is_sequence_type(SequenceType.PROTEIN, seq_str)
-    is_dna = is_sequence_type(SequenceType.DNA, seq_str)
-    is_rna = is_sequence_type(SequenceType.RNA, seq_str)
+    is_protein = is_valid_sequence(SequenceType.PROTEIN, seq_str)
+    is_dna = is_valid_sequence(SequenceType.DNA, seq_str)
+    is_rna = is_valid_sequence(SequenceType.RNA, seq_str)
 
     if is_dna and is_rna:
         return None

--- a/src/af3cli/sequence.py
+++ b/src/af3cli/sequence.py
@@ -365,7 +365,7 @@ def read_fasta(filename: str) -> Generator[tuple[str, str], None, None]:
     try:
         from Bio import SeqIO
         for entry in SeqIO.parse(filename, "fasta"):
-            yield entry.id, str(entry.seq)
+            yield entry.id, str(entry.seq).upper()
     except ImportError as e:
         raise ImportError("Please install Biopython to read FASTA files") from e
 
@@ -448,7 +448,11 @@ def fasta2seq(filename: str) -> Generator[Sequence | None, None, None]:
     for entry_name, entry_seq in read_fasta(filename):
         if entry_seq is None:
             yield None
+            continue
+
         seq_type = identify_sequence_type(entry_seq)
         if seq_type is None:
             yield None
+            continue
+
         yield Sequence(seq_type=seq_type, seq_str=entry_seq)

--- a/src/af3cli/sequence.py
+++ b/src/af3cli/sequence.py
@@ -1,5 +1,6 @@
 from enum import StrEnum
 from abc import ABCMeta
+from typing import Generator
 
 from .mixin import DictMixin
 from .exception import AFTemplateError
@@ -334,3 +335,120 @@ class Sequence(IDRecord, DictMixin):
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}({self.seq_type.name})>"
+
+
+def read_fasta(filename: str) -> Generator[tuple[str, str], None, None]:
+    """
+    Reads a FASTA file and yields sequences with their identifiers as tuples.
+
+    This function utilizes Biopython's SeqIO to parse a given FASTA file and
+    yield tuples containing sequence identifiers and their corresponding
+    sequences. The function ensures that Biopython is installed and raises
+    an appropriate error if it is not available.
+
+    Parameters
+    ----------
+    filename : str
+        Path to the FASTA file to be read.
+
+    Yields
+    ------
+    tuple of (str, str)
+        A tuple where the first element is the sequence identifier, and the
+        second element is the sequence as a string.
+
+    Raises
+    ------
+    ImportError
+        If Biopython is not installed and cannot be imported.
+    """
+    try:
+        from Bio import SeqIO
+        for entry in SeqIO.parse(filename, "fasta"):
+            yield entry.id, str(entry.seq)
+    except ImportError as e:
+        raise ImportError("Please install Biopython to read FASTA files") from e
+
+
+def is_sequence_type(seq_type: SequenceType, seq_str: str) -> bool:
+    """
+    Determines if a given sequence string corresponds to the specified sequence type.
+
+    Parameters
+    ----------
+    seq_type : SequenceType
+        Type of the sequence to validate.
+    seq_str : str
+        The sequence string to validate against the specified sequence type.
+
+    Returns
+    -------
+    bool
+        True if all characters in `seq_str` belong to the valid character set for
+        the specified `seq_type`; False otherwise.
+    """
+    SEQ_CHAR_SETS = {
+        SequenceType.PROTEIN: set("ACDEFGHIKLMNPQRSTVWY"),
+        SequenceType.DNA: set("ACGT"),
+        SequenceType.RNA: set("ACGU")
+    }
+    return all(char in SEQ_CHAR_SETS[seq_type] for char in seq_str)
+
+
+def identify_sequence_type(seq_str: str) -> SequenceType | None:
+    """
+    Identifies the type of a given biological sequence based on its composition.
+    The function examines if the sequence can be classified as DNA, RNA, or
+    protein, and returns the corresponding sequence type.
+
+    Parameters
+    ----------
+    seq_str : str
+        The biological sequence to be analyzed.
+
+    Returns
+    -------
+    SequenceType or None
+        The type of the sequence, identified as one of the following:
+        - SequenceType.DNA: If the sequence is identified as DNA.
+        - SequenceType.RNA: If the sequence is identified as RNA.
+        - SequenceType.PROTEIN: If the sequence is identified as protein.
+        Returns None if the sequence is ambiguous (e.g., qualifies as both DNA and RNA)
+        or does not fit any of the known sequence types.
+    """
+    is_protein = is_sequence_type(SequenceType.PROTEIN, seq_str)
+    is_dna = is_sequence_type(SequenceType.DNA, seq_str)
+    is_rna = is_sequence_type(SequenceType.RNA, seq_str)
+
+    if is_dna and is_rna:
+        return None
+    elif is_dna:
+        return SequenceType.DNA
+    elif is_rna:
+        return SequenceType.RNA
+    elif is_protein:
+        return SequenceType.PROTEIN
+    return None
+
+
+def fasta2seq(filename: str) -> Generator[Sequence | None, None, None]:
+    """
+    Converts a FASTA file into a sequence generator.
+
+    Parameters
+    ----------
+    filename : str
+        The path to the FASTA file to be read.
+
+    Yields
+    ------
+    Sequence or None
+        A `Sequence` object if the sequence type can be identified; otherwise, `None`.
+    """
+    for entry_name, entry_seq in read_fasta(filename):
+        if entry_seq is None:
+            yield None
+        seq_type = identify_sequence_type(entry_seq)
+        if seq_type is None:
+            yield None
+        yield Sequence(seq_type=seq_type, seq_str=entry_seq)

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -7,7 +7,7 @@ from af3cli.sequence import TemplateType, Template
 from af3cli.sequence import (Modification, ResidueModification,
                              NucleotideModification)
 from af3cli.sequence import MSA
-from af3cli.sequence import is_sequence_type, identify_sequence_type
+from af3cli.sequence import is_valid_sequence, identify_sequence_type
 from af3cli.sequence import read_fasta, fasta2seq
 
 
@@ -310,7 +310,7 @@ def test_sequence_remove_id(
     (SequenceType.DNA, "1234567", False),
 ])
 def test_is_seq_type(seq_type: SequenceType, seq_str: str, result: bool):
-    assert is_sequence_type(seq_type=seq_type, seq_str=seq_str) == result
+    assert is_valid_sequence(seq_type=seq_type, seq_str=seq_str) == result
 
 
 @pytest.mark.parametrize("seq_str,result", [

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1,10 +1,42 @@
 import pytest
 
+import io
+
 from af3cli.sequence import SequenceType, Sequence
 from af3cli.sequence import TemplateType, Template
 from af3cli.sequence import (Modification, ResidueModification,
                              NucleotideModification)
 from af3cli.sequence import MSA
+from af3cli.sequence import is_sequence_type, identify_sequence_type
+from af3cli.sequence import read_fasta, fasta2seq
+
+
+@pytest.fixture(scope="module")
+def single_fasta_file():
+    content = (">sp|Q9C0K0|BC11B_HUMAN B-cell\n"
+               "MSRRKQGNPQHLSQRELITPEADH")
+
+    return io.StringIO(content)
+
+
+@pytest.fixture(scope="module")
+def multi_protein_fasta_file():
+    content = (">sp|Q9H165|BC11A_HUMAN\n"
+               "MSRRKQGKPQHLSKREFSPEPLEA\n"
+               ">sp|Q9C0K0|BC11B_HUMAN\n"
+               "MSRRKQGNPQHLSQRELITPEADH")
+    return io.StringIO(content)
+
+
+@pytest.fixture(scope="module")
+def multi_all_fasta_file():
+    content = (">protein\n"
+               "MSRRKQGKPQHLSKREFSPEPLEA\n"
+               ">dna\n"
+               "AATTTTCCCGGGGGTTTTTTAAAA\n"
+               ">rna\n"
+               "AACCCGGGGUUUGGCCGGGAAUUU")
+    return io.StringIO(content)
 
 
 @pytest.mark.parametrize("seq_type,seq_type_value", [
@@ -268,3 +300,57 @@ def test_sequence_remove_id(
     seq = Sequence(seq_type, seq_str, seq_id=seq_id)
     seq.remove_id()
     assert seq.get_id() is None
+
+@pytest.mark.parametrize("seq_type,seq_str,result", [
+    (SequenceType.PROTEIN, "MVKVGVNGF", True),
+    (SequenceType.RNA, "AUGUGUAU", True),
+    (SequenceType.DNA, "GACCTCT", True),
+    (SequenceType.PROTEIN, "AAQAAU", False),
+    (SequenceType.RNA, "ABCDEFG", False),
+    (SequenceType.DNA, "1234567", False),
+])
+def test_is_seq_type(seq_type: SequenceType, seq_str: str, result: bool):
+    assert is_sequence_type(seq_type=seq_type, seq_str=seq_str) == result
+
+
+@pytest.mark.parametrize("seq_str,result", [
+    ("MVKVGVNGF", SequenceType.PROTEIN),
+    ("AUGUGUAU", SequenceType.RNA),
+    ("GACCTCT", SequenceType.DNA),
+    ("GACCCAAGG", None),
+    ("1234567", None),
+    ("ABCDEFG", None),
+])
+def test_identify_seq_type(seq_str: str, result: SequenceType | None):
+    assert identify_sequence_type(seq_str=seq_str) == result
+
+
+def test_read_fasta_single(single_fasta_file):
+    for entry in read_fasta(single_fasta_file):
+        assert entry[0] is not None
+        assert entry[1] is not None
+        assert isinstance(entry[0], str)
+        assert isinstance(entry[1], str)
+        assert entry[1] == "MSRRKQGNPQHLSQRELITPEADH"
+
+
+def test_fasta2seq_single(single_fasta_file):
+    for entry in fasta2seq(single_fasta_file):
+        assert entry is not None
+        assert isinstance(entry, Sequence)
+        assert entry.seq_type == SequenceType.PROTEIN
+        assert entry.seq_str == "MSRRKQGNPQHLSQRELITPEADH"
+
+
+def test_fasta2seq_multi(multi_protein_fasta_file):
+    for entry in fasta2seq(multi_protein_fasta_file):
+        assert entry is not None
+        assert isinstance(entry, Sequence)
+        assert entry.seq_type == SequenceType.PROTEIN
+
+
+def test_fasta2seq_multi_all(multi_all_fasta_file):
+    for entry in fasta2seq(multi_all_fasta_file):
+        assert entry is not None
+        assert isinstance(entry, Sequence)
+        assert entry.seq_type is not None

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ dev = [
     { name = "pytest" },
 ]
 features = [
+    { name = "biopython" },
     { name = "rdkit" },
 ]
 
@@ -22,7 +23,33 @@ requires-dist = [{ name = "fire", specifier = ">=0.7.0" }]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.3.4" }]
-features = [{ name = "rdkit", specifier = ">=2024.9.4" }]
+features = [
+    { name = "biopython", specifier = ">=1.84" },
+    { name = "rdkit", specifier = ">=2024.9.4" },
+]
+
+[[package]]
+name = "biopython"
+version = "1.84"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/7f/eaca4de03f0ee06c9d578d2730fd55858a57cee3620c62d3bc17b5da5447/biopython-1.84.tar.gz", hash = "sha256:60fbe6f996e8a6866a42698c17e552127d99a9aab3259d6249fbaabd0e0cc7b4", size = 25793001 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/7b/c1e9f66e23b01958ae0284a437a0e586ce20387fc6ea0382c21230ac59bc/biopython-1.84-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2d4ed30aebd96b4aadeb1f04adce92795c696f5bd56d1fd45517b89059918dd4", size = 2754460 },
+    { url = "https://files.pythonhosted.org/packages/5f/49/c9ffacca2e26259e28215e0ac599db21adf4070359d2aa9d006f3ecf1051/biopython-1.84-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c792508988fc3ccf18eaae2a826c9cd97f1c27fb55bb87bdce6a101fee9f5a0c", size = 2737878 },
+    { url = "https://files.pythonhosted.org/packages/b4/d6/5aae16c1dd91284a40b769926cd69214ddbb986e710f6d44dbe1f6f20c34/biopython-1.84-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:507ac3956f3107e77fee362ecb048dafb5f97cbcf110012d091418430c3227c7", size = 3174779 },
+    { url = "https://files.pythonhosted.org/packages/4c/3c/cecf231afa65e7194ac06ba981631a9870515bb7a37a15cad1ab414325c4/biopython-1.84-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:894ee7533cca7f5f9769e2595fbe7b0dba5018f39a2170753d101a13e7585ff4", size = 3192041 },
+    { url = "https://files.pythonhosted.org/packages/0f/6c/3e8f01ddea31eeba4cddaa6dbb37b7978ea0164bd35b783fda9f5be59cc4/biopython-1.84-cp311-cp311-win32.whl", hash = "sha256:7f4c746825721ec367c2f2d6a8cda3bc6495a1e084e5b2fbab26e9467706603f", size = 2755506 },
+    { url = "https://files.pythonhosted.org/packages/89/38/e45df36e10de29141ba0e5d94bfb942925e62cb6ad182e58b74fa5edcfcc/biopython-1.84-cp311-cp311-win_amd64.whl", hash = "sha256:2cb8e839ab472244b6082635ad1df67c94c05df0bd02a023103ed00ea66c4d20", size = 2792261 },
+    { url = "https://files.pythonhosted.org/packages/f7/f6/a61af0d2c8c04e446bce4727e8124797132858f518b6d6543d0e7213abed/biopython-1.84-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:ba58a6d76288333c5f178a426116953fa68204bd0cfc401694087dd4f96d0059", size = 2755863 },
+    { url = "https://files.pythonhosted.org/packages/e9/1a/25c7df41987383070987f7b9842f48d3a33b0a78a85c2ca9d93ed810fa2a/biopython-1.84-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ee3566f6dc3acf20e238540daf896f0af20cff531521bf41fdf5143f73e209ae", size = 2738072 },
+    { url = "https://files.pythonhosted.org/packages/a2/b2/c7f2a0a151208c634ac1eaa5d6345899659b1d5a700a84ef2e4f2b0e80a9/biopython-1.84-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89ef3967f5a88b5bb6344bef75ae83386de53fed3966d5c8c334ad885f8db08a", size = 3186633 },
+    { url = "https://files.pythonhosted.org/packages/46/37/7db2bcbb396edba3f767dd89ac23ef5adc35c7a92ef3912c06d1e71469e1/biopython-1.84-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61765b71f84814a1eeb55ab222f43330aa7ad3e55ab91e8b444706149c67a281", size = 3206061 },
+    { url = "https://files.pythonhosted.org/packages/b2/12/6c9d73cbb8c9d19ab4187aaf187f967de6e83738947b7180fdd8bc9211a2/biopython-1.84-cp312-cp312-win32.whl", hash = "sha256:52b6098f47d6b90fc8a5e8579b81ee50047e9108f0976e69c891ae0c4817e42d", size = 2756622 },
+    { url = "https://files.pythonhosted.org/packages/d1/53/91d12cc254a804c797afaefec91ede04bc1f7cbd788a04ebbea9e31ee0cf/biopython-1.84-cp312-cp312-win_amd64.whl", hash = "sha256:ecff2fcf5da29b600474c0bfcdbbac0f98b25e22fe60a853d0ee798c00f7396c", size = 2792652 },
+]
 
 [[package]]
 name = "colorama"


### PR DESCRIPTION
### Overview of Changes

#### New Features

- Extended `add` command for sequences to read an entry from a FASTA file.
- New `fasta` top-level command to read multiple sequences with automatic assignment of sequence types.
- Sequence characters will be checked depending on the specified sequence type to ensure valid sequences.
- The function for reading SDF ligand files is now part of the library code.

#### Testing

- Added unit tests for new features.

#### Notes

- Biopython is used for handling FASTA files and has to be installed as an optional dependency.
- If several sequences are read from a FASTA file, the sequence type must be determined automatically. In the rare case that this does not work, the respective sequence is ignored and must be added separately. 
- The sequence characters are only automatically validated in the CLI as soon as a new sequence is added. When using the Python library, the function `is_valid_sequence` must be called independently for greater flexibility. The responsibility for generating a valid input for AlphaFold3 is then up to the user.