### PR TITLE
Fixed issue with writing CCD codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ The ligands are treated in a generally similar way to the sequences and can be d
 ```shell
 af3cli [...] \
     - ligand add --smiles "CCC" \
+    # providing a list of CCD codes is also supported
     - ligand add --ccd "MG" \
     - ligand add --sdf ligands.sdf
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ authors = [
 requires-python = ">=3.11"
 dependencies = [
     "fire>=0.7.0",
-    "ipykernel>=6.29.5",
 ]
 
 [project.scripts]
@@ -30,6 +29,9 @@ dev = [
 features = [
     "biopython>=1.84",
     "rdkit>=2024.9.4",
+]
+examples = [
+    "ipykernel>=6.29.5",
 ]
 
 [tool.uv]

--- a/src/af3cli/__main__.py
+++ b/src/af3cli/__main__.py
@@ -775,7 +775,7 @@ class LigandCommand(CLICommand):
     def add(
         self,
         smiles: str | None = None,
-        ccd: str | None = None,
+        ccd: list[str] | str | None = None,
         sdf: str | None = None,
         num: int | None = None,
         ids: list[str] | None = None
@@ -796,7 +796,7 @@ class LigandCommand(CLICommand):
             SMILES representation of the ligand if provided. Must not be used
             simultaneously with `ccd` or `sdf`.
 
-        ccd : str
+        ccd : list[str] or str
             CCD identifier of the ligand if provided. Must not be used
             simultaneously with `smiles` or `sdf`.
 
@@ -857,7 +857,7 @@ class LigandCommand(CLICommand):
                 )
             return self
 
-        ligand_str = smiles or ccd
+        ligand_str = smiles or ensure_opt_str_list(ccd)
         ligand_type = LigandType.SMILES if smiles else LigandType.CCD
 
         # append the single ligand to a list to unify the finalization code

--- a/src/af3cli/ligand.py
+++ b/src/af3cli/ligand.py
@@ -76,6 +76,10 @@ class Ligand(IDRecord, DictMixin):
         dict
             A dictionary containing the object's ID and ligand data.
         """
+        if isinstance(self.ligand_str, str) and \
+            self.ligand_type == LigandType.CCD:
+            # otherwise the CCD name string will be treated as list of chars
+            self.ligand_str = [self.ligand_str]
         content = dict()
         content["id"] = self.get_id()
         content[self.ligand_type.value] = self.ligand_str

--- a/uv.lock
+++ b/uv.lock
@@ -7,12 +7,14 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fire" },
-    { name = "ipykernel" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+]
+examples = [
+    { name = "ipykernel" },
 ]
 features = [
     { name = "biopython" },
@@ -20,14 +22,11 @@ features = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "fire", specifier = ">=0.7.0" },
-    { name = "ipykernel", specifier = ">=6.29.5" },
-]
+requires-dist = [{ name = "fire", specifier = ">=0.7.0" }]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.3.4" }]
-fasta = []
+examples = [{ name = "ipykernel", specifier = ">=6.29.5" }]
 features = [
     { name = "biopython", specifier = ">=1.84" },
     { name = "rdkit", specifier = ">=2024.9.4" },


### PR DESCRIPTION
Only lists of strings are supported for `"ccdCodes"` in `"ligand"` entries. If a single CCD code was provided, only a single string was written and therefore treated as a list of chars.