### PR TITLE
Fixed issues with empty sequence IDs, Version 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "af3cli"
-version = "0.3.0"
+version = "0.3.1"
 description = """
 A command-line interface and Python library for generating AlphaFold3 input files.
 """

--- a/src/af3cli/__init__.py
+++ b/src/af3cli/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from .ligand import Ligand, LigandType, SMILigand, CCDLigand
 from .sequence import Sequence, SequenceType

--- a/src/af3cli/input.py
+++ b/src/af3cli/input.py
@@ -78,7 +78,7 @@ class InputFile(DictMixin):
                 if seq_ids is not None:
                     for seq_id in seq_ids:
                         self._id_register.register(seq_id)
-                        entry.is_registered = True
+                    entry.set_registered()
 
     def _assign_ids(self) -> None:
         """

--- a/src/af3cli/input.py
+++ b/src/af3cli/input.py
@@ -108,12 +108,12 @@ class InputFile(DictMixin):
         self._id_register.reset()
 
     def merge(
-            self,
-            other: InputFile,
-            reset: bool = True,
-            seeds: bool = False,
-            bonded_atoms: bool = False,
-            userccd: bool = False
+        self,
+        other: InputFile,
+        reset: bool = True,
+        seeds: bool = False,
+        bonded_atoms: bool = False,
+        userccd: bool = False
     ) -> None:
         """
         Merges the content of another InputFile instance into the current

--- a/src/af3cli/ligand.py
+++ b/src/af3cli/ligand.py
@@ -1,5 +1,3 @@
-from abc import ABCMeta
-
 from enum import StrEnum
 from typing import Generator
 

--- a/src/af3cli/ligand.py
+++ b/src/af3cli/ligand.py
@@ -99,7 +99,7 @@ class CCDLigand(Ligand):
     def __init__(
         self,
         ligand_value: list[str],
-        num: int | None = None,
+        num: int = 1,
         seq_id: list[str] | None = None
     ):
         super().__init__(LigandType.CCD, ligand_value, num, seq_id)
@@ -112,7 +112,7 @@ class SMILigand(Ligand):
     def __init__(
         self,
         ligand_value: list[str] | str,
-        num: int | None = None,
+        num: int = 1,
         seq_id: list[str] | None = None
     ):
         super().__init__(LigandType.SMILES, ligand_value, num, seq_id)

--- a/src/af3cli/seqid.py
+++ b/src/af3cli/seqid.py
@@ -56,17 +56,47 @@ class IDRecord(object):
     """
     def __init__(self, num: int = 1, seq_id: list[str] | None = None):
         self._seq_id: list[str] | None = seq_id
-        if self._seq_id is None:
-            self._num: int = num
-        else:
-            self._num: int = len(self._seq_id)
+        self._num: int = num
         self._is_registered: bool = False
+        self._sanitize_seq_id(seq_id)
+        self._sanitize_num(num)
 
-    def _update_num(self) -> None:
+    def _sanitize_seq_id(self, seq_id: list[str] | None) -> None:
+        """
+        Sanitizes the sequence identifier.
+
+        This method processes the provided sequence identifier `seq_id`. If `seq_id`
+        is None or contains no elements, the internal `_seq_id` attribute is set
+        to None. Otherwise, `_seq_id` is updated with the given `seq_id`.
+
+        Parameters
+        ----------
+        seq_id : list of str or None
+            A list of sequence identifiers. If None or an empty list is
+            provided, the internal `_seq_id` attribute is set to None; otherwise,
+            it is assigned the provided list.
+        """
+        if seq_id is None or len(seq_id) == 0:
+            self._seq_id = None
+        else:
+            self._seq_id =  seq_id
+
+    def _sanitize_num(self, num: int = 1) -> None:
+        """
+        Sanitizes and updates the `_num` attribute based on given input or the
+        length of `_seq_id`.
+
+        Parameters
+        ----------
+        num : int, optional
+            An integer value indicating the desired number. Defaults to 1.
+        """
         if self._seq_id is None:
-            self._num = 1
+            self._num = num
         else:
             self._num = len(self._seq_id)
+        if num < 1:
+            self._num = 1
 
     @property
     def num(self) -> int:
@@ -99,10 +129,9 @@ class IDRecord(object):
         - This function sets the registered flag to False. Please reset the corresponding
           `IDRegister` if the object is already attached to `InputFile` to prevent ID clashes.
         """
-        if isinstance(seq_id, list) and len(seq_id) == 0:
-            self._seq_id = None
         self._seq_id = seq_id
-        self._update_num()
+        self._sanitize_seq_id(seq_id)
+        self._sanitize_num()
         self._is_registered = False
 
     def remove_id(self) -> None:

--- a/src/af3cli/seqid.py
+++ b/src/af3cli/seqid.py
@@ -51,31 +51,62 @@ class IDRecord(object):
     _num : int or None
         The number of ligand sequences, default is 1.T his value
         will be overwritten if `seq_id` is specified.
-    is_registered : bool
+    _is_registered : bool
         A flag indicating whether the record is already registered or not.
     """
     def __init__(self, num: int = 1, seq_id: list[str] | None = None):
-        self._seq_id: list[str] | None= seq_id
+        self._seq_id: list[str] | None = seq_id
         if self._seq_id is None:
-            self._num = num
+            self._num: int = num
         else:
-            self._num = len(seq_id)
-        self.is_registered: bool = False
+            self._num: int = len(self._seq_id)
+        self._is_registered: bool = False
+
+    def _update_num(self) -> None:
+        if self._seq_id is None:
+            self._num = 1
+        else:
+            self._num = len(self._seq_id)
 
     @property
     def num(self) -> int:
         return self._num
 
-    def get_id(self) -> list[str]:
+    @property
+    def is_registered(self) -> bool:
+        return self._is_registered
+
+    def set_registered(self) -> None:
+        self._is_registered = True
+
+    def get_id(self) -> list[str] | None:
         return self._seq_id
 
-    def set_id(self, seq_id: list[str]) -> None:
+    def set_id(self, seq_id: list[str] | None) -> None:
+        """
+        Set a new sequence identifier for the object. If an empty list is passed as the
+        sequence identifier, the identifier will be set to None. After updating the sequence
+        identifier, the method triggers the update of internal numbering.
+
+        Parameters
+        ----------
+        seq_id : list of str or None
+            A list of string sequence identifiers to be associated with the object. If
+            an empty list is passed, the sequence identifier is set to None.
+
+        Notes
+        -------
+        - This function sets the registered flag to False. Please reset the corresponding
+          `IDRegister` if the object is already attached to `InputFile` to prevent ID clashes.
+        """
+        if isinstance(seq_id, list) and len(seq_id) == 0:
+            self._seq_id = None
         self._seq_id = seq_id
-        self._num = len(seq_id)
+        self._update_num()
+        self._is_registered = False
 
     def remove_id(self) -> None:
-        self._seq_id = None
-        self.is_registered = False
+        self.set_id(None)
 
 
 class IDRegister(object):

--- a/tests/test_seqid.py
+++ b/tests/test_seqid.py
@@ -1,6 +1,7 @@
 import pytest
 
-from af3cli.seqid import num_to_letters, IDRegister
+from af3cli.seqid import num_to_letters
+from af3cli.seqid import IDRecord, IDRegister
 
 
 @pytest.mark.parametrize("num,letters", [
@@ -55,3 +56,42 @@ def test_id_register_reset(register: IDRegister) -> None:
     register.reset()
     assert len(register._registered_ids) == 0
     assert register._count == 0
+
+@pytest.mark.parametrize("num,ids", [
+    (1, ["A"]), (2, ["A", "B"]), (3, ["A", "B", "C"]),
+    (4, ["A"]), (6, ["A", "B", "C", "D"]), (1, None),
+    (6, None)
+])
+def test_id_record(num: int, ids: list[str] | None) -> None:
+    entity = IDRecord(num, ids)
+    assert entity.get_id() == ids
+    if ids is None:
+        assert entity.num == num
+    else:
+        assert entity.num == len(ids)
+
+
+@pytest.mark.parametrize("ids", [
+    ["A"], ["A", "B"], ["A", "B", "C"], [], None
+])
+def test_id_record_assign(ids: list[str] | None) -> None:
+    entity = IDRecord()
+    entity.set_id(ids)
+    if ids is not None and len(ids) == 0:
+        assert entity.get_id() is None
+        assert entity.num == 1
+    else:
+        assert entity.get_id() == ids
+
+    if ids is None or len(ids) == 0:
+        assert entity.num == 1
+    else:
+        assert entity.num == len(ids)
+
+
+def test_id_record_remove() -> None:
+    entity = IDRecord(seq_id=["A", "B", "C"])
+    entity.remove_id()
+    assert entity.get_id() is None
+    assert entity.num == 1
+    assert entity.is_registered == False


### PR DESCRIPTION
### Overview of Changes

- empty sequence ID lists are now correctly handled
- removing sequence IDs results in unregistered entities now
- registration status is now private and can be accessed via read-only property
- added unit tests for `IDRecord`
- changed version to 0.3.1