### PR TITLE
Fundamental change to ID management, Version 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,9 +369,11 @@ af3cli [...] \
     - ligand add [...] -n 5
 ```
 
-You can also specify IDs or a number in connection with an SDF file, whereby it should be noted that the number of manually specified IDs must correspond to the number of ligands in the SDF file. If a number is specified, all entries in the SDF are then multiplied by this number.
+You can also specify IDs or a number in connection with an SDF file, whereby it should be noted that the number of manually specified IDs must correspond to the number of ligands in the SDF file. If a number is specified, all entries in the SDF are then multiplied by this number. Since all entries in the SDF file are converted to a SMILES string, manual ID assignment is not needed as bonded atoms are only available for CCD entries.
 
-In Python, the number or explicit IDs can be specified when initializing `Ligand` or `Sequence` objects. If both parameters are specified, IDs are prioritized. The registration or automatic assignment of IDs only takes place in connection with an `InputFile` object and is carried out when the file is converted into a dictionary (e.g. when the file is written). If the IDs of a sequence are changed after they have already been registered, the `IDRegister` must be reset.
+In Python, the number or explicit IDs can be specified when initializing `Ligand` or `Sequence` objects. If both parameters are specified, IDs are prioritized. If the number of IDs assigned is therefore greater than the number, the latter is overwritten. In the opposite case, missing IDs are populated automatically. This also facilitates subsequent changes to the number.
+
+The registration or automatic assignment of IDs only takes place in connection with an `InputFile` object and is carried out when the file is converted into a dictionary (e.g. when the file is written). If the IDs of a sequence are changed after they have already been registered, the `IDRegister` must be reset.
 
 ```python
 ligand = SMILigand(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "af3cli"
-version = "0.3.1"
+version = "0.4.0"
 description = """
 A command-line interface and Python library for generating AlphaFold3 input files.
 """

--- a/src/af3cli/__init__.py
+++ b/src/af3cli/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 
 from .ligand import Ligand, LigandType, SMILigand, CCDLigand
 from .sequence import Sequence, SequenceType

--- a/src/af3cli/__main__.py
+++ b/src/af3cli/__main__.py
@@ -936,6 +936,9 @@ class LigandCommand(CLICommand):
                 )
             return self
 
+        if isinstance(smiles, list | tuple):
+            exit_on_error("Only a single SMILES string can be provided.")
+
         ligand_str = smiles or ensure_opt_str_list(ccd)
         ligand_type = LigandType.SMILES if smiles else LigandType.CCD
 

--- a/src/af3cli/__main__.py
+++ b/src/af3cli/__main__.py
@@ -917,6 +917,8 @@ class LigandCommand(CLICommand):
             # the correponding id values if specified, otherwise the
             # ids cannot be assigned
             if ids is not None:
+                logger.info("Explicit ID assignment is not needed for SDF "
+                            "as each entry is converted to SMILES.")
                 if len(ids) != len(sdf_smiles):
                     exit_on_error("Number of ids does not "
                                   "match number of SDF entries.")

--- a/src/af3cli/builder.py
+++ b/src/af3cli/builder.py
@@ -57,7 +57,7 @@ class InputBuilder(object):
         Self
             Returns the instance itself to allow method chaining.
         """
-        self._afinput.reset_ids()
+        self._afinput.reset_all_ids()
         return self
 
     def build(self) -> InputFile:

--- a/src/af3cli/ligand.py
+++ b/src/af3cli/ligand.py
@@ -49,12 +49,9 @@ class Ligand(IDRecord, DictMixin):
         self._ligand_value: list[str] | str  = ligand_value
         self._ligand_type: LigandType = ligand_type
 
-        # can be overwritten if seq_id is specified
-        self._num: int = num
-
-        if seq_id is not None:
-            self._seq_id: list[str] = seq_id
-            self._num: int = len(seq_id)
+        # can be overwritten if length of seq_id is larger
+        self.num = num
+        self.set_id(seq_id)
 
     @property
     def ligand_type(self) -> LigandType:
@@ -88,7 +85,7 @@ class Ligand(IDRecord, DictMixin):
                 raise ValueError(f"Invalid ligand type: {self._ligand_type}")
 
         content = dict()
-        content["id"] = self.get_id()
+        content["id"] = self.get_full_id_list()
         content[self._ligand_type.value] = self._ligand_value
         return {"ligand": content}
 

--- a/src/af3cli/ligand.py
+++ b/src/af3cli/ligand.py
@@ -74,10 +74,19 @@ class Ligand(IDRecord, DictMixin):
         dict
             A dictionary containing the object's ID and ligand data.
         """
-        if isinstance(self._ligand_value, str) and \
-            self._ligand_type == LigandType.CCD:
-            # otherwise the CCD name string will be treated as list of chars
-            self._ligand_value = [self._ligand_value]
+        match self._ligand_type:
+            case LigandType.CCD:
+                if isinstance(self._ligand_value, str):
+                    # otherwise the CCD name string will be treated as list of chars
+                    self._ligand_value = [self._ligand_value]
+            case LigandType.SMILES:
+                if isinstance(self._ligand_value, list):
+                    if len(self._ligand_value) != 1:
+                        raise ValueError("SMILES value must be a single string")
+                    self._ligand_value, _ = self._ligand_value
+            case _:
+                raise ValueError(f"Invalid ligand type: {self._ligand_type}")
+
         content = dict()
         content["id"] = self.get_id()
         content[self._ligand_type.value] = self._ligand_value
@@ -109,7 +118,7 @@ class SMILigand(Ligand):
     """
     def __init__(
         self,
-        ligand_value: list[str] | str,
+        ligand_value: str,
         num: int = 1,
         seq_id: list[str] | None = None
     ):

--- a/src/af3cli/sequence.py
+++ b/src/af3cli/sequence.py
@@ -280,6 +280,8 @@ class Sequence(IDRecord, DictMixin):
         self._seq_type: SequenceType = seq_type
         self.seq_name: str = seq_name
 
+        # will be overwritten if len(seq_id) is larger
+        self.num = num
         self._msa: MSA | None = msa
 
         if modifications is None:
@@ -293,9 +295,9 @@ class Sequence(IDRecord, DictMixin):
             templates = []
         self._templates: list[Template] = templates
 
-        if seq_id is not None:
-            self._seq_id: list[str] = seq_id
-            self._num: int = len(seq_id)
+        # this will overwrite the sequence count if the length
+        # is larger than the specified number
+        self.set_id(seq_id)
 
     @property
     def sequence(self) -> str:
@@ -369,7 +371,7 @@ class Sequence(IDRecord, DictMixin):
             )
 
         content = dict()
-        content["id"] = self.get_id()
+        content["id"] = self.get_full_id_list()
         content["sequence"] = self._seq_str
         if len(self._modifications):
             content["modifications"] = [m.to_dict() for m in self._modifications]

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -61,7 +61,7 @@ def test_builder_set_name(builder: InputBuilder) -> None:
 ])
 def test_builder_set_seeds(builder: InputBuilder, seeds: list[int]) -> None:
     builder.set_seeds(seeds)
-    assert sorted(list(builder.build().seeds)) == sorted(seeds)
+    assert sorted(list(builder.build().seeds)) == sorted(list(set(seeds)))
 
 
 def test_builder_set_version(builder: InputBuilder) -> None:

--- a/tests/test_ligand.py
+++ b/tests/test_ligand.py
@@ -54,12 +54,14 @@ def test_ligand_to_dict(
 
 @pytest.mark.parametrize("cls,lig_type,lig_str,num,seq_id,actual_num",[
     (CCDLigand, LigandType.CCD, ["NAC"], 1, None, 1),
+    (CCDLigand, LigandType.CCD, ["CMPD1", "CMPD2"], 1, None, 1),
+    (CCDLigand, LigandType.CCD, "NAC", 1, None, 1),
     (CCDLigand, LigandType.CCD, ["ATP"], 2, ["A", "B"], 2),
     (SMILigand, LigandType.SMILES, "CCC", 1, None, 1),
     (SMILigand, LigandType.SMILES, "CCC", 1, None, 1),
     (SMILigand, LigandType.SMILES, "CCC", 2, None, 2),
     (SMILigand, LigandType.SMILES, "CCC", 2, ["A", "B"], 2),
-    (SMILigand, LigandType.SMILES, "CCC", 1, ["A", "B"], 2)
+    (SMILigand, LigandType.SMILES, ["CCC"], 1, ["A", "B"], 2)
 ])
 def test_ligand_child_classes(
         cls,
@@ -74,3 +76,9 @@ def test_ligand_child_classes(
     assert ligand.ligand_value == lig_str
     assert ligand.num == actual_num
     assert ligand.get_id() == seq_id
+
+
+def test_invalid_ligand() -> None:
+    with pytest.raises(ValueError):
+        ligand = SMILigand(["CCC", "CCO"])
+        ligand.to_dict()


### PR DESCRIPTION
### Overview of Changes

- Now, two lists of IDs are stored and separately handled to differentiate automatically assigned and explicitly stated IDs.
- Fixed an issue when adding SMILES as a list of strings instead of a string, which is expected for CCD ligands.
- Added new unit tests and fixed handling of duplicate seeds in one test case.